### PR TITLE
fix for non-standard ssh ports

### DIFF
--- a/src/frontend/mosh.cc
+++ b/src/frontend/mosh.cc
@@ -296,7 +296,7 @@ int main( int argc, char *argv[] )
     hints.ai_socktype = SOCK_STREAM;
 
     if ( ( rv = getaddrinfo( host.c_str(),
-                             port_request.size() ? port_request.c_str() : "ssh",
+                             port.c_str(),
                              &hints,
                              &servinfo ) ) != 0 ) {
       die( "%s: Could not resolve hostname %s: getaddrinfo: %s",


### PR DESCRIPTION
Hello, there's a bug in using the mosh cxxwrapper to connect to non-standard ssh ports.

The port_request variable is the mosh udp port, while the port variable is the ssh port via proxycommand

Thanks!
